### PR TITLE
Fix for issues (closed) #12 and #13 and allows usage of phpfastcache 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "contao/core-bundle": "^3.5.1 || ~4.1",
     "codefog/contao-haste": ">=4.10,<5-dev",
     "tijsverkoyen/css-to-inline-styles": "~1.5",
-    "phpFastCache/phpFastCache": "^5.0",
+    "phpFastCache/phpFastCache": "^5.0|^7.0",
     "roderik/pwgen-php": ">=0.1.5",
     "html2text/html2text": "~4.0",
     "globalcitizen/php-iban": "~2.0",

--- a/config/config.php
+++ b/config/config.php
@@ -9,7 +9,7 @@ $GLOBALS['TL_CONFIG']['phpfastcachePath'] = 'system/cache/phpfastcache/';
  * Add jquery to backend
  */
 if (TL_MODE == 'BE') {
-    $strJQueryPath = version_compare(VERSION, '4.0', '<') ? 'assets/jquery/core/' . $GLOBALS['TL_ASSETS']['JQUERY'] . '/jquery.min.js' : 'assets/jquery/js/jquery.min.js';
+    $strJQueryPath = version_compare(VERSION, '4.0', '<') ? 'assets/jquery/core/' . $GLOBALS['TL_ASSETS']['JQUERY'] . '/jquery.min.js|static' : 'assets/jquery/js/jquery.min.js|static';
     if (isset($GLOBALS['TL_JAVASCRIPT']['jquery'])) {
         unset($GLOBALS['TL_JAVASCRIPT']['jquery']);
     }
@@ -18,7 +18,7 @@ if (TL_MODE == 'BE') {
     }
     array_insert($GLOBALS['TL_JAVASCRIPT'], 0, [
         'jquery'            => $strJQueryPath,
-        'jquery-noconflict' => 'system/modules/haste_plus/assets/js/jquery-noconflict.min.js',
+        'jquery-noconflict' => 'system/modules/haste_plus/assets/js/jquery-noconflict.min.js|static',
     ]);
 }
 


### PR DESCRIPTION
This patch solves jquery undefined error in backend on contao 4.6 and allows usage of version 7.0 of phpfastcache (which is required by other packages)