### PR TITLE
Fix wrong autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
   },
   "autoload": {
     "psr-0": {
-      "HeimrichHannot\\Haste\\": [
+      "HeimrichHannot\\": [
         "library/"
       ]
     }


### PR DESCRIPTION
This PR fixes the wrong autoloading definition in the `composer.json`. Since you already use a physical `Haste` subfolder, you must not add it to the root namespace. Alternatively you could also move all folders/files within `library/Haste/` one folder up instead (i.e. getting rid of the `Haste/` subfolder in `library/`).

```
Deprecation Notice: Class HeimrichHannot\Haste\Database\Contao3MysqliHelper located in ./vendor/heimrichhannot/contao-haste_plus/library/Haste/Database/QueryHelper.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0.
```

The autoloading will not work with the new Contao Manager anymore, which is due to be released soon, since it uses Composer 2.x.