### PR TITLE
change version of phpfastcache to version that supports php8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "contao/core-bundle": "^3.5.1 || ^4.4.52",
     "codefog/contao-haste": ">=4.10,<5-dev",
     "tijsverkoyen/css-to-inline-styles": "^2.2",
-    "phpfastcache/phpfastcache": "^5.0 || ^6.1.5 ",
+    "phpfastcache/phpfastcache": "^5.0 || ^6.1.5 || ^9.0",
     "hackzilla/password-generator": "^1.4",
     "soundasleep/html2text": "^1.1",
     "globalcitizen/php-iban": "~2.0",


### PR DESCRIPTION
This PR changes the version phpfastcache to a version that support PHP version 8.