### PR TITLE
fixed haste call using raw function arguments causing error

### DIFF
--- a/library/Haste/Util/Url.php
+++ b/library/Haste/Util/Url.php
@@ -402,12 +402,18 @@ class Url
         $arguments = func_get_args();
         array_shift($arguments);
         array_shift($arguments);
+
         $container = System::getContainer();
-        if (class_exists(UrlParser::class) && $container->has(UrlParser::class)) {
+
+        if (class_exists(UrlParser::class) && $container->has(UrlParser::class))
+        {
             return $container->get(UrlParser::class)->{$method}(...$arguments);
-        } elseif (class_exists(\Haste\Util\Url::class)) {
-            return \Haste\Util\Url::{$method}(...func_get_args());
         }
+        elseif (class_exists(\Haste\Util\Url::class))
+        {
+            return \Haste\Util\Url::{$method}(...$arguments);
+        }
+
         return $default;
     }
 }


### PR DESCRIPTION
With php8, the original code caused an error due to the typed parameter being invalid. I assume the method would have returned early in php7 resulting in a wrong return value.

Please check. :)